### PR TITLE
Add utils for xarray logic and demonstrate with sample data contribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "xarray",
+    "skimage",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy",
     "xarray",
-    "skimage",
+    "scikit-image",
 ]
 
 [project.optional-dependencies]

--- a/src/napari_xarray/__init__.py
+++ b/src/napari_xarray/__init__.py
@@ -3,6 +3,8 @@ try:
 except ImportError:
     __version__ = "unknown"
 
+from ._sample_data import cells3d
 
 __all__ = (
-    )
+    "cells3d",
+)

--- a/src/napari_xarray/_sample_data.py
+++ b/src/napari_xarray/_sample_data.py
@@ -22,12 +22,11 @@ def cells3d() -> list[tuple]:
         LayerDataTuple suitable for direct use in napari.
     """
     # Physical scaling parameters
-    Z_SCALE = 0.29  # μm per z-slice
-    Y_SCALE = 0.26  # μm per pixel
-    X_SCALE = 0.22  # μm per pixel
+    PIXEL_SCALE = 0.26  # μm per slice/pixel
     
     # Load the cells3d dataset from scikit-image
     raw_data = data.cells3d()
+    print(raw_data.shape)
     
     # Create the xarray with rich metadata
     cells3d_xarray = xr.DataArray(
@@ -35,10 +34,10 @@ def cells3d() -> list[tuple]:
         name='cells3d',
         dims=['Z', 'C', 'Y', 'X'],
         coords={
-            'Z': np.arange(raw_data.shape[0]) * Z_SCALE,  # scaled z coordinates
+            'Z': np.arange(raw_data.shape[0]) * PIXEL_SCALE,  # scaled z coordinates
             'C': ['membrane', 'nuclei'],  # channel names
-            'Y': np.arange(raw_data.shape[2]) * Y_SCALE,  # scaled y coordinates
-            'X': np.arange(raw_data.shape[3]) * X_SCALE,  # scaled x coordinates
+            'Y': np.arange(raw_data.shape[2]) * PIXEL_SCALE,  # scaled y coordinates
+            'X': np.arange(raw_data.shape[3]) * PIXEL_SCALE,  # scaled x coordinates
         },
         attrs={
             'scale_units': {

--- a/src/napari_xarray/_sample_data.py
+++ b/src/napari_xarray/_sample_data.py
@@ -1,0 +1,76 @@
+"""Sample data for napari-xarray."""
+
+import numpy as np
+import xarray as xr
+from skimage import data
+
+from .utils import get_layerdatatuple_from_xarray
+
+def cells3d() -> list[tuple]:
+    """Create a 4D cells3d xarray with rich metadata for napari visualization.
+    
+    This function creates an xarray.DataArray from scikit-image's cells3d dataset
+    with comprehensive metadata including:
+    - Named dimensions and coordinates
+    - Channel-specific colormaps and contrast limits
+    - Scale information with units
+    - Proper coordinate scaling for spatial dimensions
+
+    Returns
+    -------
+    list of tuple
+        LayerDataTuple suitable for direct use in napari.
+    """
+    # Physical scaling parameters
+    Z_SCALE = 0.29  # μm per z-slice
+    Y_SCALE = 0.26  # μm per pixel
+    X_SCALE = 0.22  # μm per pixel
+    
+    # Load the cells3d dataset from scikit-image
+    raw_data = data.cells3d()
+    
+    # Create the xarray with rich metadata
+    cells3d_xarray = xr.DataArray(
+        data=raw_data,
+        name='cells3d',
+        dims=['Z', 'C', 'Y', 'X'],
+        coords={
+            'Z': np.arange(raw_data.shape[0]) * Z_SCALE,  # scaled z coordinates
+            'C': ['membrane', 'nuclei'],  # channel names
+            'Y': np.arange(raw_data.shape[2]) * Y_SCALE,  # scaled y coordinates
+            'X': np.arange(raw_data.shape[3]) * X_SCALE,  # scaled x coordinates
+        },
+        attrs={
+            'scale_units': {
+                'Z': 'μm', 
+                'Y': 'μm', 
+                'X': 'μm'
+            },
+            'colormaps': {
+                'membrane': 'orange',
+                'nuclei': 'cyan'
+            },
+            'contrast_limits': {
+                'membrane': (0, 28000),
+                'nuclei': (0, 60000),
+            },
+            'description': 'A 3D fluorescence microscopy dataset of cells with membrane and nuclei channels',
+            'source': 'scikit-image cells3d dataset',
+        }
+    )
+
+    # Use the utility function to create LayerDataTuples
+    membrane_tuple = get_layerdatatuple_from_xarray(
+        cells3d_xarray, 
+        dim='C', 
+        label='membrane'
+    )
+
+    nuclei_tuple = get_layerdatatuple_from_xarray(
+        cells3d_xarray, 
+        dim='C', 
+        label='nuclei',
+        blending='additive'
+    )
+
+    return [membrane_tuple, nuclei_tuple]

--- a/src/napari_xarray/_tests/test_sample_data.py
+++ b/src/napari_xarray/_tests/test_sample_data.py
@@ -1,0 +1,40 @@
+"""Tests for sample data functions."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from napari_xarray._sample_data import cells3d
+
+
+def test_cells3d():
+    """Test the cells3d sample data function."""
+    layer_tuples = cells3d()
+    
+    # Check it returns a list of 2 LayerDataTuples
+    assert isinstance(layer_tuples, list)
+    assert len(layer_tuples) == 2
+    
+    # Check each tuple has the correct structure (data, metadata, layer_type)
+    for layer_tuple in layer_tuples:
+        assert isinstance(layer_tuple, tuple)
+        assert len(layer_tuple) == 3
+        
+        data, metadata, layer_type = layer_tuple
+        
+        # Check data is numpy array with correct shape (60, 256, 256) - 3D after channel selection
+        assert isinstance(data, np.ndarray)
+        assert data.shape == (60, 256, 256)
+        
+        # Check metadata is dict with required keys
+        assert isinstance(metadata, dict)
+        assert "name" in metadata
+        assert "scale" in metadata
+        
+        # Check layer type
+        assert layer_type == "image"
+    
+    # Check specific layer names
+    layer_names = [layer[1]["name"] for layer in layer_tuples]
+    assert "membrane" in layer_names
+    assert "nuclei" in layer_names

--- a/src/napari_xarray/_tests/test_utils.py
+++ b/src/napari_xarray/_tests/test_utils.py
@@ -1,0 +1,232 @@
+"""Tests for utility functions."""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from napari_xarray.utils import get_scale_from_coords, get_layerdatatuple_from_xarray
+
+
+class TestGetScaleFromCoords:
+    """Tests for get_scale_from_coords function."""
+
+    def test_uniform_spacing_1d(self):
+        """Test with uniform spacing in 1D."""
+        data = xr.DataArray(
+            np.random.rand(10),
+            dims=['X'],
+            coords={'X': np.arange(10) * 0.5}  # 0.5 spacing
+        )
+        scale = get_scale_from_coords(data, ['X'])
+        assert len(scale) == 1
+        assert scale[0] == pytest.approx(0.5)
+
+    def test_uniform_spacing_3d(self):
+        """Test with uniform spacing in 3D."""
+        data = xr.DataArray(
+            np.random.rand(5, 10, 15),
+            dims=['Z', 'Y', 'X'],
+            coords={
+                'Z': np.arange(5) * 0.3,   # 0.3 spacing
+                'Y': np.arange(10) * 0.2,  # 0.2 spacing
+                'X': np.arange(15) * 0.1,  # 0.1 spacing
+            }
+        )
+        scale = get_scale_from_coords(data, ['Z', 'Y', 'X'])
+        assert len(scale) == 3
+        assert scale[0] == pytest.approx(0.3)
+        assert scale[1] == pytest.approx(0.2)
+        assert scale[2] == pytest.approx(0.1)
+
+    def test_scalar_coordinates(self):
+        """Test with scalar (0D) coordinates."""
+        data = xr.DataArray(
+            np.random.rand(10),
+            dims=['X'],
+            coords={'X': 1.5}  # scalar coordinate
+        )
+        scale = get_scale_from_coords(data, ['X'])
+        assert len(scale) == 1
+        assert scale[0] == 1.5
+
+    def test_mixed_uniform_nonuniform_spacing(self):
+        """Test with non-uniform spacing (should use mean difference)."""
+        data = xr.DataArray(
+            np.random.rand(5),
+            dims=['X'],
+            coords={'X': [0, 1, 3, 6, 10]}  # non-uniform: diffs are [1, 2, 3, 4]
+        )
+        scale = get_scale_from_coords(data, ['X'])
+        expected_mean = np.mean([1, 2, 3, 4])  # 2.5
+        assert scale[0] == pytest.approx(expected_mean)
+
+    def test_subset_of_dimensions(self):
+        """Test selecting only some dimensions."""
+        data = xr.DataArray(
+            np.random.rand(5, 10, 15),
+            dims=['Z', 'Y', 'X'],
+            coords={
+                'Z': np.arange(5) * 0.3,
+                'Y': np.arange(10) * 0.2,
+                'X': np.arange(15) * 0.1,
+            }
+        )
+        scale = get_scale_from_coords(data, ['Y', 'X'])  # only Y and X
+        assert len(scale) == 2
+        assert scale[0] == pytest.approx(0.2)  # Y
+        assert scale[1] == pytest.approx(0.1)  # X
+
+
+class TestGetLayerDataTupleFromXarray:
+    """Tests for get_layerdatatuple_from_xarray function."""
+
+    @pytest.fixture
+    def sample_xarray(self):
+        """Create a sample xarray for testing."""
+        data = np.random.rand(2, 10, 15)  # 2 channels, 10x15 spatial
+        return xr.DataArray(
+            data=data,
+            dims=['C', 'Y', 'X'],
+            coords={
+                'C': ['channel1', 'channel2'],
+                'Y': np.arange(10) * 0.5,
+                'X': np.arange(15) * 0.2,
+            },
+            attrs={
+                'colormaps': {
+                    'channel1': 'red',
+                    'channel2': 'green'
+                },
+                'contrast_limits': {
+                    'channel1': (0, 100),
+                    'channel2': (10, 200),
+                },
+            }
+        )
+
+    def test_basic_functionality(self, sample_xarray):
+        """Test basic LayerDataTuple creation."""
+        layer_tuple = get_layerdatatuple_from_xarray(
+            sample_xarray, 
+            dim='C', 
+            label='channel1'
+        )
+        
+        # Check tuple structure
+        assert isinstance(layer_tuple, tuple)
+        assert len(layer_tuple) == 3
+        
+        data, metadata, layer_type = layer_tuple
+        
+        # Check data
+        assert isinstance(data, np.ndarray)
+        assert data.shape == (10, 15)  # C dimension removed
+        
+        # Check metadata
+        assert isinstance(metadata, dict)
+        assert metadata['name'] == 'channel1'
+        assert metadata['colormap'] == 'red'
+        assert metadata['contrast_limits'] == (0, 100)
+        assert len(metadata['scale']) == 2  # Y and X dimensions
+        
+        # Check layer type
+        assert layer_type == 'image'
+
+    def test_with_kwargs(self, sample_xarray):
+        """Test with additional kwargs."""
+        layer_tuple = get_layerdatatuple_from_xarray(
+            sample_xarray, 
+            dim='C', 
+            label='channel2',
+            blending='additive',
+            opacity=0.7,
+            visible=False
+        )
+        
+        data, metadata, layer_type = layer_tuple
+        
+        # Check that kwargs were added to metadata
+        assert metadata['blending'] == 'additive'
+        assert metadata['opacity'] == 0.7
+        assert metadata['visible'] == False
+        
+        # Check original metadata still present
+        assert metadata['name'] == 'channel2'
+        assert metadata['colormap'] == 'green'
+
+    def test_kwargs_override_defaults(self, sample_xarray):
+        """Test that kwargs override default metadata."""
+        layer_tuple = get_layerdatatuple_from_xarray(
+            sample_xarray, 
+            dim='C', 
+            label='channel1',
+            name='custom_name',  # override default name
+            colormap='blue'      # override default colormap
+        )
+        
+        data, metadata, layer_type = layer_tuple
+        
+        # Check overrides
+        assert metadata['name'] == 'custom_name'
+        assert metadata['colormap'] == 'blue'
+        
+        # Check non-overridden values remain
+        assert metadata['contrast_limits'] == (0, 100)
+
+    def test_missing_metadata(self):
+        """Test with missing colormap and contrast_limits metadata."""
+        data = np.random.rand(2, 5, 8)
+        xarray_no_metadata = xr.DataArray(
+            data=data,
+            dims=['C', 'Y', 'X'],
+            coords={
+                'C': ['ch1', 'ch2'],
+                'Y': np.arange(5) * 0.1,
+                'X': np.arange(8) * 0.1,
+            }
+            # No attrs with colormaps or contrast_limits
+        )
+        
+        layer_tuple = get_layerdatatuple_from_xarray(
+            xarray_no_metadata, 
+            dim='C', 
+            label='ch1'
+        )
+        
+        data, metadata, layer_type = layer_tuple
+        
+        # Should have None for missing metadata
+        assert metadata['colormap'] is None
+        assert metadata['contrast_limits'] is None
+        
+        # But should still have name and scale
+        assert metadata['name'] == 'ch1'
+        assert 'scale' in metadata
+
+    def test_different_layer_type(self, sample_xarray):
+        """Test with different layer type."""
+        layer_tuple = get_layerdatatuple_from_xarray(
+            sample_xarray, 
+            dim='C', 
+            label='channel1',
+            layer_type='labels'
+        )
+        
+        data, metadata, layer_type = layer_tuple
+        assert layer_type == 'labels'
+
+    def test_scale_calculation(self, sample_xarray):
+        """Test that scale is calculated correctly."""
+        layer_tuple = get_layerdatatuple_from_xarray(
+            sample_xarray, 
+            dim='C', 
+            label='channel1'
+        )
+        
+        data, metadata, layer_type = layer_tuple
+        scale = metadata['scale']
+        
+        # Should have scale for Y and X (excluding C)
+        assert len(scale) == 2
+        assert scale[0] == pytest.approx(0.5)  # Y spacing
+        assert scale[1] == pytest.approx(0.2)  # X spacing

--- a/src/napari_xarray/napari.yaml
+++ b/src/napari_xarray/napari.yaml
@@ -6,3 +6,11 @@ visibility: public
 # categories: []
 contributions:
   commands:
+    - id: napari-xarray.cells3d
+      python_name: napari_xarray._sample_data:cells3d
+      title: Load example xarray 3D cells dataset
+      
+  sample_data:
+    - command: napari-xarray.cells3d
+      display_name: xarray cells3d
+      key: unique_id.0

--- a/src/napari_xarray/utils.py
+++ b/src/napari_xarray/utils.py
@@ -19,8 +19,8 @@ def get_layerdatatuple_from_xarray(
     da: "xr.DataArray",
     dim: str,
     label: str,
-    layer_type: str = "image",
     blending: str | None = None,
+    layer_type: str = "image",
 ) -> tuple:
     """Convert a DataArray slice to a napari LayerDataTuple.
 
@@ -43,12 +43,6 @@ def get_layerdatatuple_from_xarray(
         A LayerDataTuple compatible with napari.
     """
     
-    if "colormaps" not in da.attrs or label not in da.attrs["colormaps"]:
-        raise ValueError(f"Colormap for label '{label}' not found in DataArray attributes.")
-
-    if "contrast_limits" not in da.attrs or label not in da.attrs["contrast_limits"]:
-        raise ValueError(f"Contrast limits for label '{label}' not found in DataArray attributes.")
-
     # Determine spatial dimensions (excluding the sliced dimension)
     spatial_dims = [str(d) for d in da.dims if d != dim]
     
@@ -56,12 +50,10 @@ def get_layerdatatuple_from_xarray(
 
     layer_dict = {
         "name": label,
-        "colormap": da.attrs["colormaps"][label],
-        "contrast_limits": da.attrs["contrast_limits"][label],
+        "colormap": da.attrs.get("colormaps", {}).get(label),
+        "contrast_limits": da.attrs.get("contrast_limits", {}).get(label),
         "scale": scale,
+        "blending": blending,
     }
-
-    if blending is not None:
-        layer_dict["blending"] = blending
 
     return (da.sel({dim: label}).data, layer_dict, layer_type)

--- a/src/napari_xarray/utils.py
+++ b/src/napari_xarray/utils.py
@@ -19,8 +19,8 @@ def get_layerdatatuple_from_xarray(
     da: "xr.DataArray",
     dim: str,
     label: str,
-    blending: str | None = None,
     layer_type: str = "image",
+    **kwargs,
 ) -> tuple:
     """Convert a DataArray slice to a napari LayerDataTuple.
 
@@ -32,10 +32,11 @@ def get_layerdatatuple_from_xarray(
         The dimension to slice on (e.g., 'C' for channels).
     label : str
         The specific label in the dimension to select (e.g., 'membrane').
-    blending : str | None, optional
-        The blending mode for the layer (e.g., 'additive'), by default None.
     layer_type : str, optional
         The type of napari layer (default is 'image').
+    **kwargs
+        Additional keyword arguments to pass to the napari layer
+        (e.g., blending='additive', opacity=0.8, visible=False, etc.).
 
     Returns
     -------
@@ -48,12 +49,15 @@ def get_layerdatatuple_from_xarray(
     
     scale = get_scale_from_coords(da, dims=spatial_dims)
 
-    layer_dict = {
+    # Start with base metadata from xarray attributes
+    metadata = {
         "name": label,
         "colormap": da.attrs.get("colormaps", {}).get(label),
         "contrast_limits": da.attrs.get("contrast_limits", {}).get(label),
         "scale": scale,
-        "blending": blending,
     }
+    
+    # Add any additional kwargs (this will override base metadata if there are conflicts)
+    metadata.update(kwargs)
 
-    return (da.sel({dim: label}).data, layer_dict, layer_type)
+    return (da.sel({dim: label}).data, metadata, layer_type)

--- a/src/napari_xarray/utils.py
+++ b/src/napari_xarray/utils.py
@@ -42,9 +42,7 @@ def get_layerdatatuple_from_xarray(
     tuple
         A LayerDataTuple compatible with napari.
     """
-
-    label = str(da.coords[dim].values.item())
-
+    
     if "colormaps" not in da.attrs or label not in da.attrs["colormaps"]:
         raise ValueError(f"Colormap for label '{label}' not found in DataArray attributes.")
 
@@ -52,7 +50,7 @@ def get_layerdatatuple_from_xarray(
         raise ValueError(f"Contrast limits for label '{label}' not found in DataArray attributes.")
 
     # Determine spatial dimensions (excluding the sliced dimension)
-    spatial_dims = [d for d in da.dims if d != dim]
+    spatial_dims = [str(d) for d in da.dims if d != dim]
     
     scale = get_scale_from_coords(da, dims=spatial_dims)
 

--- a/src/napari_xarray/utils.py
+++ b/src/napari_xarray/utils.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import xarray as xr
+import numpy as np
+
+def get_scale_from_coords(da: xr.DataArray, dims: list[str]) -> tuple[float, ...]:
+    scale = []
+    for dim in dims:
+        # get scalar value if 0D array
+        if da.coords[dim].values.ndim == 0:
+            scalar = da.coords[dim].values
+        # get scalar value from finding the mean difference between coords and data shape
+        else:
+            scalar = np.mean(np.diff(da.coords[dim].values))
+        scale.append(scalar)
+    return tuple(scale)
+
+def get_layerdatatuple_from_xarray(
+    da: "xr.DataArray",
+    dim: str,
+    label: str,
+    layer_type: str = "image",
+    blending: str | None = None,
+) -> tuple:
+    """Convert a DataArray slice to a napari LayerDataTuple.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        The input xarray DataArray.
+    dim : str
+        The dimension to slice on (e.g., 'C' for channels).
+    label : str
+        The specific label in the dimension to select (e.g., 'membrane').
+    blending : str | None, optional
+        The blending mode for the layer (e.g., 'additive'), by default None.
+    layer_type : str, optional
+        The type of napari layer (default is 'image').
+
+    Returns
+    -------
+    tuple
+        A LayerDataTuple compatible with napari.
+    """
+
+    label = str(da.coords[dim].values.item())
+
+    if "colormaps" not in da.attrs or label not in da.attrs["colormaps"]:
+        raise ValueError(f"Colormap for label '{label}' not found in DataArray attributes.")
+
+    if "contrast_limits" not in da.attrs or label not in da.attrs["contrast_limits"]:
+        raise ValueError(f"Contrast limits for label '{label}' not found in DataArray attributes.")
+
+    # Determine spatial dimensions (excluding the sliced dimension)
+    spatial_dims = [d for d in da.dims if d != dim]
+    
+    scale = get_scale_from_coords(da, dims=spatial_dims)
+
+    layer_dict = {
+        "name": label,
+        "colormap": da.attrs["colormaps"][label],
+        "contrast_limits": da.attrs["contrast_limits"][label],
+        "scale": scale,
+    }
+
+    if blending is not None:
+        layer_dict["blending"] = blending
+
+    return (da.sel({dim: label}).data, layer_dict, layer_type)

--- a/src/napari_xarray/utils.py
+++ b/src/napari_xarray/utils.py
@@ -4,6 +4,44 @@ import xarray as xr
 import numpy as np
 
 def get_scale_from_coords(da: xr.DataArray, dims: list[str]) -> tuple[float, ...]:
+    """Extract scale values from xarray coordinates for napari visualization.
+    
+    This function calculates the physical spacing between data points along
+    specified dimensions by analyzing the coordinate values. For scalar coordinates,
+    it returns the coordinate value directly. For array coordinates, it computes
+    the mean difference between consecutive coordinate values.
+    
+    Parameters
+    ----------
+    da : xr.DataArray
+        The input xarray DataArray containing coordinate information.
+    dims : list[str]
+        List of dimension names to extract scale values for. These should
+        correspond to spatial dimensions (e.g., ['Z', 'Y', 'X']).
+    
+    Returns
+    -------
+    tuple[float, ...]
+        Tuple of scale values corresponding to the input dimensions.
+        Each value represents the physical spacing per pixel/voxel
+        along that dimension.
+    
+    Examples
+    --------
+    >>> import xarray as xr
+    >>> import numpy as np
+    >>> data = xr.DataArray(
+    ...     np.random.rand(10, 20, 30),
+    ...     dims=['Z', 'Y', 'X'],
+    ...     coords={
+    ...         'Z': np.arange(10) * 0.5,  # 0.5 μm per z-slice
+    ...         'Y': np.arange(20) * 0.2,  # 0.2 μm per pixel
+    ...         'X': np.arange(30) * 0.2,  # 0.2 μm per pixel
+    ...     }
+    ... )
+    >>> get_scale_from_coords(data, ['Z', 'Y', 'X'])
+    (0.5, 0.2, 0.2)
+    """
     scale = []
     for dim in dims:
         # get scalar value if 0D array


### PR DESCRIPTION
# References and relevant issues

At the least, this will make tests not red!

# Description

1. Adds util functions to get napari-related info from xarray metadata (whether that is scale or using attrs)
2. Adds sample data contribution `xarray cells 3d` to demonstrate this functionality
3. Adds tests for utils and sample data

Sample data (note the abnormal scaling -- not sure if we should do "regular" scaling or use this to really show that something is different)
<img width="1298" height="1030" alt="image" src="https://github.com/user-attachments/assets/4512062b-463e-44cc-95b2-c6ff8ce6aaad" />

